### PR TITLE
[docs] fix code block render on `api.py/slice`

### DIFF
--- a/grapheme/api.py
+++ b/grapheme/api.py
@@ -68,8 +68,8 @@ def slice(string: str, start=None, end=None) -> str:
     Returns a substring of the given string, counting graphemes instead of codepoints.
 
     Negative indices is currently not supported.
-    >>> string = "tamil நி (ni)"
 
+    >>> string = "tamil நி (ni)"
     >>> string[:7]
     'tamil ந'
     >>> grapheme.slice(string, end=7)


### PR DESCRIPTION
Fixed the rendering of the code block in `api.py/slice`

# Before
<img width="1536" height="670" alt="image" src="https://github.com/user-attachments/assets/559eefdf-d31d-42b5-9688-e6637ec8adc4" />

# After
<img width="1524" height="712" alt="image" src="https://github.com/user-attachments/assets/4b3da8ff-44e1-40ec-8e87-2d605f5a8044" />

(Note: I did the same PR for the original grapheme repo, before noticing it's no longer maintained.)